### PR TITLE
fixed crash due to off-by-one array access in PXPalette_removeColorAtIndex()

### DIFF
--- a/Pixel Art Core/Palette/PXPalette.m
+++ b/Pixel Art Core/Palette/PXPalette.m
@@ -744,8 +744,8 @@ void PXPalette_removeColorAtIndex(PXPalette *self, unsigned int index)
 		self->colors[i - 1] = self->colors[i];
 		PXPalette_bucketForColor(self, self->colors[i].color)->index--;
 	}
-	self->colors[self->colorCount].color = nil;
-	self->colors[self->colorCount].frequency = 0;
+	self->colors[self->colorCount - 1].color = nil;
+	self->colors[self->colorCount - 1].frequency = 0;
 	self->colorCount -= 1;
 	PXPalette_saveChanges(self);
 }


### PR DESCRIPTION
This is a two-line fix for a reproducible crash I was getting:
1. Start with an existing image that contains a few colors
2. Using the rectangle or lasso tool, make a selection that contains all the pixels of one or more specific colors (so that if those pixels were removed, the color(s) would be removed from the palette)
3. Hit 'Delete' or 'Cmd-X' to remove the selected pixels from the image

Occasionally the steps would have to be repeated before it crashed, but it was pretty consistent on my 10.5 G5 tower.
