### PR TITLE
fixed second eyedropper tool

### DIFF
--- a/Pixen Application/Tools/Tools/PXEyedropperTool.m
+++ b/Pixen Application/Tools/Tools/PXEyedropperTool.m
@@ -88,7 +88,7 @@
 {
 	if(![[controller canvas] containsPoint:aPoint]) { return; }
 	id usedSwitcher;
-	if ([(PXEyedropperToolPropertiesView *)propertiesView targetToolButton] == PXLeftButtonTool)
+	if ([[self propertiesView] targetToolButton] == PXLeftButtonTool)
 		usedSwitcher = [[PXToolPaletteController sharedToolPaletteController] leftSwitcher];
 	else
 		usedSwitcher = [[PXToolPaletteController sharedToolPaletteController] rightSwitcher];


### PR DESCRIPTION
was selecting color for the left-click tool instead.

found the code next to "// immense HACK ohgodimsorry"
was not being used, so I found a place to use it.
