### PR TITLE
First batch of marking instance variables as private

### DIFF
--- a/Pixel Art Core/Background/PXBackground.m
+++ b/Pixel Art Core/Background/PXBackground.m
@@ -176,7 +176,7 @@
 
 - (id)initWithCoder:(NSCoder *)coder
 {
-	[super init];
+	self = [super init];
 	[self setName:[coder decodeObjectForKey:@"name"]];
 	[self configurator];
 	return self;

--- a/Pixel Art Core/Background/PXDuotoneBackground.m
+++ b/Pixel Art Core/Background/PXDuotoneBackground.m
@@ -95,9 +95,9 @@
 	[super encodeWithCoder:coder];
 }
 
--(id) initWithCoder:(NSCoder *)coder
+- (id)initWithCoder:(NSCoder *)coder
 {
-	[super initWithCoder:coder];
+	self = [super initWithCoder:coder];
 	[self setBackColor:[coder decodeObjectForKey:@"backColor"]];
 	return self;
 }

--- a/Pixel Art Core/Background/PXMonotoneBackground.m
+++ b/Pixel Art Core/Background/PXMonotoneBackground.m
@@ -105,11 +105,11 @@
     [super encodeWithCoder:coder];
 }
 
--(id) initWithCoder:(NSCoder *) coder
+- (id)initWithCoder:(NSCoder *)coder
 {
-    [super initWithCoder:coder];
-    [self setColor:[coder decodeObjectForKey:@"color"]];
-    return self;
+	self = [super initWithCoder:coder];
+	[self setColor:[coder decodeObjectForKey:@"color"]];
+	return self;
 }
 
 -(id) copyWithZone:(NSZone *)zone

--- a/Pixen Application/Animation/PXAnimationBackgroundView.h
+++ b/Pixen Application/Animation/PXAnimationBackgroundView.h
@@ -9,6 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 @interface PXAnimationBackgroundView : NSView {
+  @private
 	NSGradient *horizontalGradient;
 	NSScrollView *filmStrip;
 }

--- a/Pixen Application/Animation/PXAnimationDocument.h
+++ b/Pixen Application/Animation/PXAnimationDocument.h
@@ -10,6 +10,7 @@
 #import "PXDocument.h"
 @class PXAnimationWindowController, PXAnimation;
 @interface PXAnimationDocument : PXDocument {
+  @private
 	PXAnimation *animation;
 }
 

--- a/Pixen Application/Animation/PXAnimationDocument.m
+++ b/Pixen Application/Animation/PXAnimationDocument.m
@@ -28,16 +28,16 @@
 
 - (void)dealloc
 {
-	[(PXAnimationWindowController *)windowController setAnimation:nil];
+	[ (PXAnimationWindowController *) self.windowController setAnimation:nil];
 	[animation release];
 	[super dealloc];
 }
 
 //FIXME: consider removing these three once coupling decreases
 
-- canvasController
+- (id)canvasController
 {
-	return [windowController canvasController];
+	return [self.windowController canvasController];
 }
 
 - canvas
@@ -50,19 +50,19 @@
   return [animation canvases];
 }
 
-- (void)delete:sender
+- (void)delete:(id)sender
 {
-  [windowController delete:sender];
+	[self.windowController delete:sender];
 }
 
 - (void)initWindowController
 {
-    windowController = [[PXAnimationWindowController alloc] initWithWindowNibName:@"PXAnimationDocument"];
+	self.windowController = [[[PXAnimationWindowController alloc] initWithWindowNibName:@"PXAnimationDocument"] autorelease];
 }
 
 - (void)setWindowControllerData
 {
-	[(PXAnimationWindowController *)windowController setAnimation:animation];
+	[ (PXAnimationWindowController *) self.windowController setAnimation:animation];
 }
 
 - (NSFileWrapper *)fileWrapperOfType:(NSString *)aType error:(NSError **)outError
@@ -116,7 +116,10 @@
 		int i;
 		int numberOfCels = [animation countOfCels];
 		[popup setMaxProgress:numberOfCels];
-		[popup beginOperationWithStatusText:[NSString stringWithFormat:@"Exporting GIF... (1 of %d)", numberOfCels] parentWindow:[windowController window]];
+		
+		[popup beginOperationWithStatusText:[NSString stringWithFormat:@"Exporting GIF... (1 of %d)", numberOfCels]
+							   parentWindow:[self.windowController window]];
+		
 		[popup setProgress:0];
 		id exportAnimation = [[animation copy] autorelease];
 		[exportAnimation reduceColorsTo:256 withTransparency:YES matteColor:[NSColor whiteColor]];

--- a/Pixen Application/Animation/PXAnimationPreview.h
+++ b/Pixen Application/Animation/PXAnimationPreview.h
@@ -10,6 +10,7 @@
 
 
 @interface PXAnimationPreview : NSView {
+  @private
 	NSTimer *animationTimer;
 	id currentCel;
 	int currentIndex;

--- a/Pixen Application/Animation/PXAnimationWindowController.h
+++ b/Pixen Application/Animation/PXAnimationWindowController.h
@@ -11,6 +11,7 @@
 #import "PXCanvasWindowController.h"
 @class PXAnimation, PXCel, PXFilmStripView, PXAnimationPreview, RBSplitSubview;
 @interface PXAnimationWindowController : PXCanvasWindowController {
+  @private
 	PXAnimation *animation;
 	IBOutlet PXFilmStripView *filmStrip;
 	IBOutlet PXAnimationPreview *animationPreview;

--- a/Pixen Application/Animation/PXAnimationWindowController.m
+++ b/Pixen Application/Animation/PXAnimationWindowController.m
@@ -158,7 +158,7 @@
 		
 		[self updateDeleteButtonState];
 	} else if ([keyPath isEqualToString:@"size"]) {
-		[canvasController updateCanvasSize];
+		[self.canvasController updateCanvasSize];
 	}
 }
 
@@ -471,7 +471,7 @@
 		for (i = 0; i < celCount; i++)
 		{
 			if ([[animation objectInCelsAtIndex:i] canvas] == currentCanvas) { continue; }
-			[scaleController scaleCanvas:[[animation objectInCelsAtIndex:i] canvas]];
+			[self.scaleController scaleCanvas:[[animation objectInCelsAtIndex:i] canvas]];
 		}
 	}
 	[[[self document] undoManager] endUndoGrouping];
@@ -479,7 +479,7 @@
 
 - (IBAction)scaleCanvas:(id) sender
 {
-	[scaleController setDelegate:self withCallback:@selector(scalePrompterFinished:shouldScale:)];
+	[self.scaleController setDelegate:self withCallback:@selector(scalePrompterFinished:shouldScale:)];
 	[[[self document] undoManager] beginUndoGrouping];
 	[super scaleCanvas:self];
 }
@@ -494,10 +494,10 @@ didFinishWithSize:(NSSize)aSize
 
 - (IBAction)crop:sender
 {
-	NSRect selectedRect = [canvas selectedRect];
+	NSRect selectedRect = [self.canvas selectedRect];
 	[[[self document] undoManager] beginUndoGrouping];
 	[animation setSize:selectedRect.size withOrigin:NSMakePoint(NSMinX(selectedRect) * -1, NSMinY(selectedRect) * -1) backgroundColor:[[NSColor clearColor] colorUsingColorSpaceName:NSDeviceRGBColorSpace]];
-	[canvas deselect];
+	[self.canvas deselect];
 	[[[self document] undoManager] endUndoGrouping];
 }
 

--- a/Pixen Application/Animation/PXFilmStripView.h
+++ b/Pixen Application/Animation/PXFilmStripView.h
@@ -10,6 +10,7 @@
 
 @interface PXFilmStripView : NSView
 {
+  @private
 	id dataSource;
 	id delegate;
 	

--- a/Pixen Application/Animation/PXNewCelButton.h
+++ b/Pixen Application/Animation/PXNewCelButton.h
@@ -10,6 +10,7 @@
 
 
 @interface PXNewCelButton : NSView {
+  @private
 	int state;
 	NSBezierPath *buttonPath, *plusPath;
 	id delegate;

--- a/Pixen Application/Application/PXApplication.h
+++ b/Pixen Application/Application/PXApplication.h
@@ -22,6 +22,7 @@ COPYRIGHT
 #import <AppKit/NSApplication.h>
 
 @interface PXApplication : NSApplication {
+  @private
 	BOOL	_needToWatchMouseEvents;
 }
 - (void) handleMouseEvent:(NSEvent *)theEvent;

--- a/Pixen Application/Application/PXDocument.h
+++ b/Pixen Application/Application/PXDocument.h
@@ -10,9 +10,12 @@
 
 @class PXCanvas, PXCanvasWindowController;
 @interface PXDocument : NSDocument {
+  @private
 	IBOutlet PXCanvasWindowController *windowController;
 }
-- (PXCanvasWindowController *)windowController;
+
+@property (nonatomic, retain) IBOutlet PXCanvasWindowController *windowController;
+
 - (PXCanvas *)canvas;
 - (NSArray *)canvases;
 - (BOOL)containsCanvas:(PXCanvas *)c;

--- a/Pixen Application/Application/PXDocument.m
+++ b/Pixen Application/Application/PXDocument.m
@@ -13,6 +13,8 @@
 
 @implementation PXDocument
 
+@synthesize windowController;
+
 - (void)dealloc
 {
 	[[self windowControllers] makeObjectsPerformSelector:@selector(close)];
@@ -83,8 +85,4 @@
 	[[NSNotificationCenter defaultCenter] postNotificationName:PXDocumentChangedDisplayNameNotificationName object:self];
 }
 
-- (PXCanvasWindowController *)windowController;
-{
-	return windowController;
-}
 @end

--- a/Pixen Application/Application/PXDocumentController.h
+++ b/Pixen Application/Application/PXDocumentController.h
@@ -31,6 +31,7 @@
 
 @interface PXDocumentController: NSDocumentController
 {
+  @private
 	BOOL cachedShowsToolPreview, cachedShowsPreviousCelOverlay;
 	NSTimer *mouseTrackingTimer;
 }

--- a/Pixen Application/Background/PXBackgroundController.h
+++ b/Pixen Application/Background/PXBackgroundController.h
@@ -5,6 +5,7 @@
 @class PXBackgroundInfoView, PXBackgroundsTableView, PXBackground, OSStackedView, PXDefaultBackgroundTemplateView;
 @interface PXBackgroundController : NSWindowController
 {
+  @private
     IBOutlet PXBackgroundInfoView *alternateBackgroundView;
     IBOutlet PXBackgroundInfoView *mainBackgroundView;
     IBOutlet OSStackedView *mainStack, *defaultsStack;

--- a/Pixen Application/Background/PXBackgroundInfoView.h
+++ b/Pixen Application/Background/PXBackgroundInfoView.h
@@ -4,6 +4,7 @@
 @class PXBackground, PXBackgroundPreviewView;
 @interface PXBackgroundInfoView : NSView
 {
+  @private
     IBOutlet NSView *configuratorContainer;
     IBOutlet id delegate;
     IBOutlet PXBackgroundPreviewView *imageView;

--- a/Pixen Application/Background/PXBackgroundPreviewView.h
+++ b/Pixen Application/Background/PXBackgroundPreviewView.h
@@ -30,6 +30,7 @@
 
 
 @interface PXBackgroundPreviewView : NSView {
+  @private
 	NSImage *image;
 	NSRect functionalRect;
 }

--- a/Pixen Application/Background/PXBackgroundTemplateView.h
+++ b/Pixen Application/Background/PXBackgroundTemplateView.h
@@ -30,14 +30,19 @@
 
 @class PXBackground, PXBackgroundPreviewView;
 @interface PXBackgroundTemplateView : NSView {
+  @private
 	PXBackground *background;
 	IBOutlet NSView *view;
-	IBOutlet NSTextField *templateName, *templateClassName;
+	IBOutlet NSTextField *templateNameField, *templateClassNameField;
 	IBOutlet PXBackgroundPreviewView *imageView;
 }
-- (PXBackground *)background;
-- (void)setBackground:(PXBackground *)bg;
-- templateName;
-- templateClassName;
+
+@property (nonatomic, retain) PXBackground *background;
+
+@property (nonatomic, readonly) IBOutlet NSTextField *templateNameField;
+@property (nonatomic, readonly) IBOutlet NSTextField *templateClassNameField;
+@property (nonatomic, readonly) IBOutlet PXBackgroundPreviewView *imageView;
+
 - (void)setHighlighted:(BOOL)highlighted;
+
 @end

--- a/Pixen Application/Background/PXBackgroundTemplateView.m
+++ b/Pixen Application/Background/PXBackgroundTemplateView.m
@@ -33,6 +33,8 @@
 
 @implementation PXBackgroundTemplateView
 
+@synthesize background, templateNameField, templateClassNameField, imageView;
+
 - (id)initWithFrame:(NSRect)frame
 {
 	if(!(self = [super initWithFrame:frame])) { return nil; }
@@ -65,11 +67,6 @@
 	[view setFrameSize:[self frame].size];
 }
 
-- (PXBackground *)background
-{
-	return background;
-}
-
 - (void)setBackground:(PXBackground *)bg
 {
 	[background autorelease];
@@ -77,31 +74,21 @@
 	if(!bg) { return; }
 	[imageView setImage:[background previewImageOfSize:[imageView bounds].size]];
 	[imageView display];
-	[templateClassName setStringValue:[bg defaultName]];
-	[templateName setStringValue:[bg name]];
-}
-
-- templateName
-{
-	return templateName;
-}
-
-- templateClassName
-{
-	return templateClassName;
+	[templateClassNameField setStringValue:[bg defaultName]];
+	[templateNameField setStringValue:[bg name]];
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
 	if(highlighted)
 	{
-		[templateClassName setTextColor:[NSColor whiteColor]];
-		[templateName setTextColor:[NSColor whiteColor]];
+		[templateClassNameField setTextColor:[NSColor whiteColor]];
+		[templateNameField setTextColor:[NSColor whiteColor]];
 	}
 	else
 	{
-		[templateClassName setTextColor:[NSColor disabledControlTextColor]];
-		[templateName setTextColor:[NSColor blackColor]];
+		[templateClassNameField setTextColor:[NSColor disabledControlTextColor]];
+		[templateNameField setTextColor:[NSColor blackColor]];
 	}
 }
 

--- a/Pixen Application/Background/PXBuiltinBackgroundTemplateView.m
+++ b/Pixen Application/Background/PXBuiltinBackgroundTemplateView.m
@@ -14,8 +14,8 @@
 - (void)setBackground:(PXBackground *)bg
 {
 	[super setBackground:bg];
-	[templateName setStringValue:[bg defaultName]];
-	[templateClassName setStringValue:NSLocalizedString(@"Built-in Template", @"Built-in Template")];
+	[self.templateNameField setStringValue:[bg defaultName]];
+	[self.templateClassNameField setStringValue:NSLocalizedString(@"Built-in Template", @"Built-in Template")];
 }
 
 @end

--- a/Pixen Application/Background/PXDefaultBackgroundTemplateView.h
+++ b/Pixen Application/Background/PXDefaultBackgroundTemplateView.h
@@ -30,6 +30,7 @@
 #import "PXBackgroundTemplateView.h"
 
 @interface PXDefaultBackgroundTemplateView : PXBackgroundTemplateView {
+  @private
 	NSString *backgroundTypeText;
 	BOOL highlighted;
 	BOOL activeDragTarget;

--- a/Pixen Application/Background/PXDefaultBackgroundTemplateView.m
+++ b/Pixen Application/Background/PXDefaultBackgroundTemplateView.m
@@ -43,7 +43,7 @@
 {
 	[backgroundTypeText autorelease];
 	backgroundTypeText = [typeText retain];
-	[templateClassName setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Default %@", @"Default %@"), backgroundTypeText]];
+	[self.templateClassNameField setStringValue:[NSString stringWithFormat:NSLocalizedString(@"Default %@", @"Default %@"), backgroundTypeText]];
 }
 
 - (void)setActiveDragTarget:(BOOL)adt
@@ -57,15 +57,15 @@
 	[super setBackground:bg];
 	if (bg == nil)
 	{
-		[templateName setHidden:YES];
-		[templateClassName setHidden:YES];
-		[imageView setHidden:YES];
+		[self.templateNameField setHidden:YES];
+		[self.templateClassNameField setHidden:YES];
+		[self.imageView setHidden:YES];
 	}
 	else
 	{
-		[templateName setHidden:NO];
-		[templateClassName setHidden:NO];
-		[imageView setHidden:NO];
+		[self.templateNameField setHidden:NO];
+		[self.templateClassNameField setHidden:NO];
+		[self.imageView setHidden:NO];
 	}
 	
 	if (backgroundTypeText)
@@ -108,7 +108,7 @@
 		NSFrameRectWithWidth([self bounds], 3);
 	}
 	
-	if (background == nil)
+	if (self.background == nil)
 	{
 		[self drawDottedOutline];
 		[self drawNoDefaultText];

--- a/Pixen Application/Canvas/Canvas Resize Prompt/PXCanvasResizePrompter.h
+++ b/Pixen Application/Canvas/Canvas Resize Prompt/PXCanvasResizePrompter.h
@@ -42,6 +42,7 @@ didFinishWithSize:(NSSize)size
 
 @interface PXCanvasResizePrompter : NSWindowController 
 {
+  @private
 	IBOutlet NSTextField *heightField, *widthField;
 	IBOutlet PXCanvasResizeView *resizeView;
 	IBOutlet NSColorWell *bgColorWell;

--- a/Pixen Application/Canvas/Canvas Resize Prompt/PXCanvasResizeView.h
+++ b/Pixen Application/Canvas/Canvas Resize Prompt/PXCanvasResizeView.h
@@ -31,6 +31,7 @@
 
 @interface PXCanvasResizeView : NSView 
 {
+  @private
 	NSSize oldSize;
 	NSSize newSize;
 	NSPoint position;

--- a/Pixen Application/Canvas/Canvas Size Prompt/PXImageSizePrompter.h
+++ b/Pixen Application/Canvas/Canvas Size Prompt/PXImageSizePrompter.h
@@ -43,6 +43,7 @@
 @class PXNSImageView;
 @interface PXImageSizePrompter : NSWindowController 
 {
+  @private
 	IBOutlet NSTextField *widthField;
 	IBOutlet NSTextField *heightField;
 	IBOutlet PXNSImageView *preview;

--- a/Pixen Application/Canvas/PXCanvasDocument.h
+++ b/Pixen Application/Canvas/PXCanvasDocument.h
@@ -38,6 +38,7 @@
 
 @interface PXCanvasDocument : PXDocument
 {
+  @private
 	PXCanvas *canvas;
 	PXCanvasPrintView *printableView;
 	

--- a/Pixen Application/Canvas/PXCanvasDocument.m
+++ b/Pixen Application/Canvas/PXCanvasDocument.m
@@ -78,27 +78,26 @@ BOOL isPowerOfTwo(int num);
 
 - (void)dealloc
 {
-	[windowController releaseCanvas];
+	[self.windowController releaseCanvas];
 	[canvas release];
-    //	[[NSNotificationCenter defaultCenter] removeObserver:self];
-  [super dealloc];
+	//	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[super dealloc];
 }
 
 - (PXCanvasController *)canvasController
 {
-	return [windowController canvasController];
+	return [self.windowController canvasController];
 }
 
 - (void)initWindowController
 {
-  windowController = [[PXCanvasWindowController alloc] initWithWindowNibName:@"PXCanvasDocument"];
+	self.windowController = [[[PXCanvasWindowController alloc] initWithWindowNibName:@"PXCanvasDocument"] autorelease];
 }
 
 - (void)setWindowControllerData
 {
-  [windowController setCanvas:canvas];
+	[self.windowController setCanvas:canvas];
 }
-
 
 BOOL isPowerOfTwo(int num)
 {
@@ -227,18 +226,18 @@ BOOL isPowerOfTwo(int num)
 	[self updateChangeCount:NSChangeCleared];
 }
 
-- (void)delete:sender
+- (void)delete:(id)sender
 {
-	[windowController delete:sender];
+	[self.windowController delete:sender];
 }
 
 - (BOOL)readFromData:(NSData *)data ofType:(NSString *)aType error:(NSError **)error
 {
 	if([aType isEqualToString:PixenImageFileType])
-  {
+	{
 		[canvas release];
 		canvas = [[NSKeyedUnarchiver unarchiveObjectWithData:data] retain];
-  }
+	}
 	else if ([aType isEqualTo:BMPFileType])
 	{
 		[canvas release];
@@ -246,19 +245,19 @@ BOOL isPowerOfTwo(int num)
 		[canvas replaceActiveLayerWithImage:[[[NSImage alloc] initWithData:data] autorelease]];
 	}
 	else
-  {
+	{
 		NSImage *image = [[[NSImage alloc] initWithData:data] autorelease];
 		[canvas release];
 		canvas = [[PXCanvas alloc] initWithImage:image type:aType];
-  }
+	}
 	if(canvas)
-  {
+	{
 		[canvas setUndoManager:[self undoManager]];
-		[windowController setCanvas:canvas];
+		[self.windowController setCanvas:canvas];
 		[[self undoManager] removeAllActions];
 		[self updateChangeCount:NSChangeCleared]; 
 		return YES;
-  }
+	}
 	return NO;
 }
 

--- a/Pixen Application/Canvas/PXCanvasWindowController.h
+++ b/Pixen Application/Canvas/PXCanvasWindowController.h
@@ -6,10 +6,11 @@
 //
 #import <AppKit/AppKit.h>
 
-@class PXCanvasController, PXCanvas, PXCanvasView, PXBackground, RBSplitView, RBSplitSubview;
+@class PXCanvasController, PXScaleController, PXCanvas, PXCanvasView, PXBackground, RBSplitView, RBSplitSubview;
 
 @interface PXCanvasWindowController : NSWindowController
 {
+  @private
 	PXCanvas *canvas;
 
 	IBOutlet id zoomPercentageBox;
@@ -17,7 +18,7 @@
 	IBOutlet NSView *zoomView;
 	id previewController;
 	id resizePrompter;
-	id scaleController;
+	PXScaleController *scaleController;
 	id layerController;
 	
 	id paletteController;
@@ -27,16 +28,19 @@
 	IBOutlet RBSplitView *splitView;
 	IBOutlet RBSplitSubview *layerSplit, *canvasSplit, *paletteSplit;
 }
-- canvasController;
+
+@property (nonatomic, readonly) IBOutlet PXCanvasController *canvasController;
+@property (nonatomic, readonly) PXScaleController *scaleController;
+
+@property (nonatomic, assign) PXCanvas *canvas;
+
 - (PXCanvasView *)view;
 - (id) initWithWindowNibName:name;
 - (void)awakeFromNib;
 - (RBSplitSubview*)layerSplit;
 - (RBSplitSubview*)canvasSplit;
 - (void)dealloc;
-- (PXCanvas *) canvas;
 - (void)windowWillClose:note;
-- (void)setCanvas:(PXCanvas *) aCanvas;
 - (void)releaseCanvas;
 - (void)setDocument:(NSDocument *)doc;
 - (void)windowDidResignMain:note;

--- a/Pixen Application/Canvas/PXCanvasWindowController.m
+++ b/Pixen Application/Canvas/PXCanvasWindowController.m
@@ -49,6 +49,8 @@
 
 @implementation PXCanvasWindowController
 
+@synthesize scaleController, canvasController, canvas;
+
 - (PXCanvasView *)view
 {
 	return [canvasController view];
@@ -111,11 +113,6 @@
 	[toolbar release];
 	
 	[super dealloc];
-}
-
-- (PXCanvas *) canvas
-{
-	return canvas;
 }
 
 - (void)windowWillClose:note
@@ -183,11 +180,6 @@
 - (void)updateCanvasSize
 {
 	[canvasController updateCanvasSize];
-}
-
-- canvasController
-{
-	return canvasController;
 }
 
 - (void)canvasController:(PXCanvasController *)controller setSize:(NSSize)size backgroundColor:(NSColor *)bg

--- a/Pixen Application/Crosshair/PXCrosshair.h
+++ b/Pixen Application/Crosshair/PXCrosshair.h
@@ -32,7 +32,8 @@
 
 @interface PXCrosshair : NSObject 
 {
-  NSPoint cursorPosition;
+  @private
+	NSPoint cursorPosition;
 }
 
 @property (nonatomic, assign) NSPoint cursorPosition;

--- a/Pixen Application/Grid/PXGridSettingsPrompter.h
+++ b/Pixen Application/Grid/PXGridSettingsPrompter.h
@@ -39,6 +39,7 @@
 
 @interface PXGridSettingsPrompter : NSWindowController
 {
+  @private
 	IBOutlet NSForm * sizeForm;
 	IBOutlet id colorWell;
 	IBOutlet id shouldDrawCheckBox;

--- a/Pixen Application/Info Panel/PXInfoPanelController.h
+++ b/Pixen Application/Info Panel/PXInfoPanelController.h
@@ -38,6 +38,7 @@
 
 @interface PXInfoPanelController : NSObject
 {
+  @private
 	NSPoint draggingOrigin;
 		
 	IBOutlet NSPanel *panel;

--- a/Pixen Application/Layers/PXLayerController.h
+++ b/Pixen Application/Layers/PXLayerController.h
@@ -32,6 +32,7 @@
 @class PXLayer, PXCanvas, PXDocument, RBSplitSubview;
 @interface PXLayerController : NSResponder <NSCollectionViewDelegate>
 {
+  @private
 	IBOutlet NSView *view;
 	IBOutlet NSCollectionView *layersView;
 	PXCanvas *canvas;

--- a/Pixen Application/Layers/PXLayerDetailsView.h
+++ b/Pixen Application/Layers/PXLayerDetailsView.h
@@ -31,6 +31,7 @@
 @class PXNSImageView, PXLayerTextField, PXLayerController, PXLayer;
 @interface PXLayerDetailsView : NSView 
 {
+  @private
 	IBOutlet PXLayerTextField *name;
 	IBOutlet PXNSImageView *thumbnail;
 	IBOutlet NSSlider *opacity;

--- a/Pixen Application/Layers/PXLayerPaneBackgroundView.h
+++ b/Pixen Application/Layers/PXLayerPaneBackgroundView.h
@@ -7,6 +7,7 @@
 //
 
 @interface PXLayerPaneBackgroundView : NSView {
+  @private
 	NSGradient *gradient;
 }
 

--- a/Pixen Application/Layers/PXLayerTextField.h
+++ b/Pixen Application/Layers/PXLayerTextField.h
@@ -10,6 +10,7 @@
 
 
 @interface PXLayerTextField : NSTextField {
+  @private
 	BOOL isEditing;
 	BOOL isFirstEnd;
 	BOOL reachedByClicking;

--- a/Pixen Application/Welcome/PXWelcomeController.h
+++ b/Pixen Application/Welcome/PXWelcomeController.h
@@ -34,6 +34,7 @@
 
 @interface PXWelcomeController : NSWindowController
 {
+  @private
 	IBOutlet NSTabView*		tabView;			// The tabless tab-view that we're a switcher for.
 	IBOutlet id image;
 	IBOutlet id next, prev, close;


### PR DESCRIPTION
I ran into many cases where classes would be accessing their superclass's instance variables without using an accessor of some sorts. I fixed this by writing properties for those instance variables and marking them as private. Still have to go through the other half of the source tree.
