### PR TITLE
Fixed a crasher in PathUtilities.m

### DIFF
--- a/Other Sources/OSG/Utility/PathUtilities.m
+++ b/Other Sources/OSG/Utility/PathUtilities.m
@@ -66,6 +66,12 @@ NSString *GetDescriptionForDocumentType(NSString *uti)
 	else if (UTTypeEqual(cfUTI, CFSTR("com.Pixen.pxan"))) {
 		return @"Pixen animation";
 	}
+	else if (UTTypeEqual(cfUTI, CFSTR("com.opensword.pxim"))) {
+		return @"Pixen image";
+	}
+	else if (UTTypeEqual(cfUTI, CFSTR("com.opensword.pxan"))) {
+		return @"Pixen animation";
+	}
 	else if (UTTypeEqual(cfUTI, CFSTR("com.compuserve.gif"))) {
 		return @"GIF image";
 	}


### PR DESCRIPTION
I checked out Pixen and tried it out to see if I liked it.  I do, but before I buy, I want to make sure that this crasher is fixed in the App Store release.

You're parsing your old and new file formats, but your PathUtilities.m doesn't return a file type description for the old format.  This causes a crash when I open some of my old files.

-Jon
