### PR TITLE
Add shift lock while drawing with pencil tool

### DIFF
--- a/Pixen Application/Tools/Tools/PXPencilTool.h
+++ b/Pixen Application/Tools/Tools/PXPencilTool.h
@@ -9,11 +9,19 @@
 
 @class PXCanvas, PXLayer;
 
-@interface PXPencilTool : PXTool 
+typedef enum {
+    PXLockDirectionVertical,
+    PXLockDirectionHorizontal
+} PXLockDirection;
+
+@interface PXPencilTool : PXTool
 {
   @private
 	BOOL isDragging;
 	BOOL shiftDown;
+    BOOL isDragLocked;
+    PXLockDirection lockDirection;
+    NSPoint lockPoint;
 	NSRect changedRect, lastBezierBounds;
 	NSPoint movingOrigin;
   @public


### PR DESCRIPTION
Mimics the behaviour in Photoshop, with the exception of where the lock point is set. PS will
set it to the mouse down point, this commit will set it to the point at which shift is first pressed. I think this behaviour is more intuitive, although it breaks with the convention.

Addresses #232.
